### PR TITLE
Specify Go toolchain for Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,7 @@ package:
 	@echo "Done"		
 
 # Copy Service lambda to S3 location
-publish:
-	@make package
+publish: package
 	@echo ""
 	@echo "*********************************"
 	@echo "*   Publishing service lambda   *"
@@ -82,7 +81,6 @@ publish:
 	aws s3 cp $(WORKING_DIR)/lambda/bin/service/$(PACKAGE_NAME) s3://$(LAMBDA_BUCKET)/$(SERVICE_NAME)/ --output json
 	@echo "done cp"
 	rm -rf $(WORKING_DIR)/lambda/bin/service/$(PACKAGE_NAME) $(WORKING_DIR)/lambda/bin/service/bootstrap
-	@make package
 	@echo ""
 	@echo "********************************"
 	@echo "*   Publishing status lambda   *"

--- a/lambda/status/go.mod
+++ b/lambda/status/go.mod
@@ -2,4 +2,6 @@ module github.com/pennsieve/app-deploy-service/status
 
 go 1.22
 
+toolchain go1.23.4
+
 require github.com/aws/aws-lambda-go v1.47.0


### PR DESCRIPTION
The build on Jenkins requires being told of the Go toolchain to use Go 1.22.

Makefile had multiple `@make package` calls in the publish target.