### PR TITLE
Add missing perms to status lambda

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,14 @@ ansiColor('xterm') {
           string(name: 'TERRAFORM_ACTION', value: 'apply')
         ]
       }
+    } else {
+      stage ('Build') {
+        try {
+          sh "IMAGE_TAG=${imageTag} make package"
+        } finally {
+          sh "make clean"
+        }
+      }
     }
   } catch (e) {
     slackSend(color: '#b20000', message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL}) by ${authorName}")

--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,15 @@ help:
 test:
 	docker compose -f docker-compose.test.yml down --remove-orphans
 	docker compose -f docker-compose.test.yml up --exit-code-from local_tests local_tests
-	make clean
 
 # Run dockerized tests (used on Jenkins)
 test-ci:
 	docker compose -f docker-compose.test.yml down --remove-orphans
 	@IMAGE_TAG=$(IMAGE_TAG) docker compose -f docker-compose.test.yml up --exit-code-from=ci-tests ci-tests
 
-# Remove folders created by NEO4J docker container
+# Remove folders created by build
 clean: docker-clean
-	rm -rf conf
-	rm -rf data
-	rm -rf plugins
+	rm -rf $(WORKING_DIR)/lambda/bin
 
 # Spin down active docker containers.
 docker-clean:

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -180,6 +180,19 @@ data "aws_iam_policy_document" "status_iam_policy_document" {
     resources = ["*"]
   }
 
+  statement {
+    sid    = "AppDeployServiceLambdaEC2Permissions"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+      "ec2:AssignPrivateIpAddresses",
+      "ec2:UnassignPrivateIpAddresses"
+    ]
+    resources = ["*"]
+  }
+
 }
 
 # Fargate Task


### PR DESCRIPTION
The status Lambda's IAM policy was missing required EC2 permissions.

Have Jenkins build Lambdas on every branch.