### PR TITLE
Fix missing tag permssion

### DIFF
--- a/fargate/app-provisioner/main.go
+++ b/fargate/app-provisioner/main.go
@@ -79,7 +79,7 @@ func main() {
 
 		// Build and deploy
 		escClient := ecs.NewFromConfig(cfg)
-		log.Println("Initiating new Deployment Fargate Task.")
+		log.Println("Initiating new Deployment Fargate Task:", action)
 		creds, err := provisioner.AssumeRole(ctx)
 		if err != nil {
 			log.Fatal(err.Error())
@@ -154,7 +154,7 @@ func main() {
 	case "DEPLOY":
 		// Build and deploy
 		escClient := ecs.NewFromConfig(cfg)
-		log.Println("Initiating new Deployment Fargate Task.")
+		log.Println("Initiating new Deployment Fargate Task:", action)
 		creds, err := provisioner.AssumeRole(ctx)
 		if err != nil {
 			log.Fatal(err.Error())

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -309,6 +309,7 @@ data "aws_iam_policy_document" "app_provisioner_fargate_iam_policy_document" {
       "ecs:DescribeTasks",
       "ecs:RunTask",
       "ecs:ListTasks",
+      "ecs:TagResource",
       "iam:PassRole",
       "iam:PutRolePolicy",
       "iam:GetRolePolicy",


### PR DESCRIPTION
The provisioner Fargate task tags the ECS task it runs, so it needs permission to do so.