### PR TITLE
Fix Status Lambda Entrypoint error

### DIFF
--- a/lambda/status/main.go
+++ b/lambda/status/main.go
@@ -1,4 +1,4 @@
-package status
+package main
 
 import (
 	"github.com/aws/aws-lambda-go/lambda"


### PR DESCRIPTION
`make package` is creating an ar archive file for the status Lambda instead of an executable because `main.go` has the wrong package name. Package name must be `main`.