### PR TITLE
Fix Applications status field name in lambda/status

### DIFF
--- a/lambda/status/models/applications.go
+++ b/lambda/status/models/applications.go
@@ -8,7 +8,7 @@ import (
 // These *Field const must match the field names in the Applications table
 
 const ApplicationKeyField = "uuid"
-const ApplicationStatusField = "status"
+const ApplicationStatusField = "registrationStatus"
 
 func ApplicationKey(applicationId string) map[string]types.AttributeValue {
 	return map[string]types.AttributeValue{ApplicationKeyField: dydbutils.StringAttributeValue(applicationId)}


### PR DESCRIPTION
The ECS task state change handler, lambda/status is using an incorrect name for the status field in the Applications table, so that it is updating the wrong attribute when deployment is finished.

PR changes the name from the incorrect `status` to the correct `registrationStatus`.