### PR TITLE
Fix empty application uuid in provisioner/DEPLOY

### DIFF
--- a/lambda/service/handler/constants.go
+++ b/lambda/service/handler/constants.go
@@ -2,4 +2,4 @@ package handler
 
 const deploymentIdKey = "DEPLOYMENT_ID"
 const deploymentsTableNameKey = "DEPLOYMENTS_TABLE"
-const applicationIdKey = "APPLICATION_UUID"
+const applicationUuidKey = "APPLICATION_UUID"

--- a/lambda/service/handler/constants.go
+++ b/lambda/service/handler/constants.go
@@ -2,3 +2,4 @@ package handler
 
 const deploymentIdKey = "DEPLOYMENT_ID"
 const deploymentsTableNameKey = "DEPLOYMENTS_TABLE"
+const applicationIdKey = "APPLICATION_UUID"

--- a/lambda/service/handler/post_application_deploy_handler.go
+++ b/lambda/service/handler/post_application_deploy_handler.go
@@ -167,7 +167,7 @@ func PostApplicationDeployHandler(ctx context.Context, request events.APIGateway
 							Value: &envValue,
 						},
 						{
-							Name:  aws.String(applicationIdKey),
+							Name:  aws.String(applicationUuidKey),
 							Value: aws.String(applicationUuid),
 						},
 						{

--- a/lambda/service/handler/post_application_deploy_handler.go
+++ b/lambda/service/handler/post_application_deploy_handler.go
@@ -38,6 +38,8 @@ func PostApplicationDeployHandler(ctx context.Context, request events.APIGateway
 		envValue = application.Env
 	}
 
+	applicationUuid := application.Uuid
+
 	TaskDefinitionArn := os.Getenv("TASK_DEF_ARN")
 	DeployerTaskDefinitionArn := os.Getenv("DEPLOYER_TASK_DEF_ARN")
 	subIdStr := os.Getenv("SUBNET_IDS")
@@ -128,7 +130,7 @@ func PostApplicationDeployHandler(ctx context.Context, request events.APIGateway
 	if err := deploymentsStore.Insert(ctx, store_dynamodb.Deployment{
 		DeploymentKey: store_dynamodb.DeploymentKey{
 			DeploymentId:  deploymentId,
-			ApplicationId: application.Uuid,
+			ApplicationId: applicationUuid,
 		},
 		InitiatedAt:     time.Now().UTC(),
 		WorkspaceNodeId: organizationId,
@@ -143,7 +145,7 @@ func PostApplicationDeployHandler(ctx context.Context, request events.APIGateway
 		}, nil
 	}
 	applicationsStore := store_dynamodb.NewApplicationDatabaseStore(dynamoDBClient, tableValue)
-	errorHandler := NewErrorHandler(handlerName, applicationsStore, deploymentsStore, application.Uuid, deploymentId)
+	errorHandler := NewErrorHandler(handlerName, applicationsStore, deploymentsStore, applicationUuid, deploymentId)
 
 	runTaskIn := &ecs.RunTaskInput{
 		TaskDefinition: aws.String(TaskDefinitionArn),
@@ -163,6 +165,10 @@ func PostApplicationDeployHandler(ctx context.Context, request events.APIGateway
 						{
 							Name:  &envKey,
 							Value: &envValue,
+						},
+						{
+							Name:  aws.String(applicationIdKey),
+							Value: aws.String(applicationUuid),
 						},
 						{
 							Name:  &applicationNameKey,
@@ -285,7 +291,7 @@ func PostApplicationDeployHandler(ctx context.Context, request events.APIGateway
 	if len(runTaskOut.Tasks) > 0 {
 		log.Printf("started re-deployment %s of application %s from %s in task %s",
 			deploymentId,
-			application.ApplicationId,
+			applicationUuid,
 			sourceUrlValue,
 			aws.ToString(runTaskOut.Tasks[0].TaskArn))
 	}

--- a/lambda/service/handler/post_applications_handler.go
+++ b/lambda/service/handler/post_applications_handler.go
@@ -203,7 +203,6 @@ func PostApplicationsHandler(ctx context.Context, request events.APIGatewayV2HTT
 		}, nil
 	}
 
-	applicationIdKey := "APPLICATION_UUID"
 	deploymentId := uuid.NewString()
 
 	deploymentsStore := store_dynamodb.NewDeploymentsStore(dynamoDBClient, deploymentsTable)
@@ -229,7 +228,7 @@ func PostApplicationsHandler(ctx context.Context, request events.APIGatewayV2HTT
 
 	environment := []types.KeyValuePair{
 		{
-			Name:  &applicationIdKey,
+			Name:  aws.String(applicationIdKey),
 			Value: &applicationId,
 		},
 		{

--- a/lambda/service/handler/post_applications_handler.go
+++ b/lambda/service/handler/post_applications_handler.go
@@ -169,9 +169,9 @@ func PostApplicationsHandler(ctx context.Context, request events.APIGatewayV2HTT
 	}
 
 	id := uuid.New()
-	applicationId := id.String()
+	applicationUuid := id.String()
 	store_applications := store_dynamodb.Application{
-		Uuid:             applicationId,
+		Uuid:             applicationUuid,
 		Name:             nameValue,
 		Description:      descriptionValue,
 		ApplicationType:  applicationTypeValue,
@@ -209,7 +209,7 @@ func PostApplicationsHandler(ctx context.Context, request events.APIGatewayV2HTT
 	if err := deploymentsStore.Insert(ctx, store_dynamodb.Deployment{
 		DeploymentKey: store_dynamodb.DeploymentKey{
 			DeploymentId:  deploymentId,
-			ApplicationId: applicationId,
+			ApplicationId: applicationUuid,
 		},
 		InitiatedAt:     time.Now().UTC(),
 		WorkspaceNodeId: organizationId,
@@ -224,12 +224,12 @@ func PostApplicationsHandler(ctx context.Context, request events.APIGatewayV2HTT
 		}, nil
 	}
 
-	errorHandler := NewErrorHandler(handlerName, applicationsStore, deploymentsStore, applicationId, deploymentId)
+	errorHandler := NewErrorHandler(handlerName, applicationsStore, deploymentsStore, applicationUuid, deploymentId)
 
 	environment := []types.KeyValuePair{
 		{
-			Name:  aws.String(applicationIdKey),
-			Value: &applicationId,
+			Name:  aws.String(applicationUuidKey),
+			Value: &applicationUuid,
 		},
 		{
 			Name:  &envKey,
@@ -380,7 +380,7 @@ func PostApplicationsHandler(ctx context.Context, request events.APIGatewayV2HTT
 	if len(runTaskOut.Tasks) > 0 {
 		log.Printf("started provisioning and deployment %s of application %s from %s in task %s",
 			deploymentId,
-			applicationId,
+			applicationUuid,
 			sourceUrlValue,
 			aws.ToString(runTaskOut.Tasks[0].TaskArn))
 	}


### PR DESCRIPTION
PR passes the application uuid to the provisioner task as an env variable when the action is DEPLOY since the provisioner DEPLOY task now relies on this value to log status changes.