### PR TITLE
Add 'pending' status to application deploy

### DIFF
--- a/lambda/service/handler/post_application_deploy_handler.go
+++ b/lambda/service/handler/post_application_deploy_handler.go
@@ -146,6 +146,9 @@ func PostApplicationDeployHandler(ctx context.Context, request events.APIGateway
 	}
 	applicationsStore := store_dynamodb.NewApplicationDatabaseStore(dynamoDBClient, tableValue)
 	errorHandler := NewErrorHandler(handlerName, applicationsStore, deploymentsStore, applicationUuid, deploymentId)
+	if err := applicationsStore.UpdateStatus(ctx, "pending", applicationUuid); err != nil {
+		log.Printf("warning: error updating status of application %s to 'pending': %s\n", applicationUuid, err.Error())
+	}
 
 	runTaskIn := &ecs.RunTaskInput{
 		TaskDefinition: aws.String(TaskDefinitionArn),


### PR DESCRIPTION
PR adds a "pending" status to the status lifecycle of a `POST /applications/deploy`. 

Now when a user makes this POST request the status of the application will change from
- "deployed" (or "error") to "pending" before the provisioner task is started, and from
- "pending" to "re-deploying" before the deploy task is started, and then from
- "re-deploying" to "deployed" once the deploy task finishes.
