### PR TITLE
Deployment Records Deletion

### DIFF
--- a/fargate/app-provisioner/go.mod
+++ b/fargate/app-provisioner/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.9
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
+	github.com/google/uuid v1.3.0
 	github.com/pennsieve/pennsieve-go-core v1.13.0
 	github.com/pusher/pusher-http-go/v5 v5.1.1
 	github.com/stretchr/testify v1.9.0

--- a/fargate/app-provisioner/go.sum
+++ b/fargate/app-provisioner/go.sum
@@ -54,6 +54,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/fargate/app-provisioner/provisioner/status/events/applications.go
+++ b/fargate/app-provisioner/provisioner/status/events/applications.go
@@ -16,6 +16,14 @@ type ApplicationStatusEvent struct {
 	Source        string    `json:"source"`
 }
 
+const ApplicationDeletionEventName = "application_deletion_event"
+
+type ApplicationDeletionEvent struct {
+	ApplicationId string    `json:"application_id"`
+	Time          time.Time `json:"time"`
+	Source        string    `json:"source"`
+}
+
 func ApplicationStatusChannel(applicationUuid string) string {
 	return fmt.Sprintf("application-%s", applicationUuid)
 }

--- a/fargate/app-provisioner/provisioner/store_dynamodb/deployment.go
+++ b/fargate/app-provisioner/provisioner/store_dynamodb/deployment.go
@@ -1,5 +1,8 @@
 package store_dynamodb
 
+const DeploymentIdField = "deploymentId"
+const DeploymentApplicationIdField = "applicationId"
+
 type DeploymentKey struct {
 	ApplicationId string `dynamodbav:"applicationId"`
 	DeploymentId  string `dynamodbav:"deploymentId"`

--- a/fargate/app-provisioner/provisioner/store_dynamodb/deployments_store.go
+++ b/fargate/app-provisioner/provisioner/store_dynamodb/deployments_store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
@@ -13,6 +14,8 @@ import (
 // DynamoDB client methods used by DeploymentsStore
 type DeploymentsTableAPI interface {
 	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+	BatchWriteItem(ctx context.Context, params *dynamodb.BatchWriteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error)
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(options *dynamodb.Options)) (*dynamodb.QueryOutput, error)
 }
 
 type DeploymentsStore struct {
@@ -49,4 +52,53 @@ func (s *DeploymentsStore) SetErroredFlag(ctx context.Context, applicationId str
 	}
 
 	return nil
+}
+
+func (s *DeploymentsStore) DeleteApplicationDeployments(ctx context.Context, applicationId string) error {
+	expressions, err := expression.NewBuilder().
+		WithKeyCondition(expression.KeyEqual(
+			expression.Key(DeploymentApplicationIdField), expression.Value(applicationId))).
+		WithProjection(expression.NamesList(expression.Name(DeploymentIdField), expression.Name(DeploymentApplicationIdField))).
+		Build()
+	if err != nil {
+		return fmt.Errorf("error building key condition for query to delete deployments of application %s: %w", applicationId, err)
+	}
+	queryIn := &dynamodb.QueryInput{
+		TableName:                 aws.String(s.tableName),
+		ExpressionAttributeNames:  expressions.Names(),
+		ExpressionAttributeValues: expressions.Values(),
+		KeyConditionExpression:    expressions.KeyCondition(),
+		ProjectionExpression:      expressions.Projection(),
+		Limit:                     aws.Int32(25), // 25 is max number of items that can be deleted in a batch delete
+	}
+
+	for doQuery, page := true, 1; doQuery; doQuery, page = len(queryIn.ExclusiveStartKey) > 0, page+1 {
+		// Get a batch of items
+		queryOut, err := s.api.Query(ctx, queryIn)
+		if err != nil {
+			return fmt.Errorf("error getting page %d of deployments to delete for application %s: %w", page, applicationId, err)
+		}
+		// Delete this batch of items
+		deleteBatch := batchDeletes(s.tableName, queryOut.Items)
+		for len(deleteBatch) > 0 {
+			batchWriteOut, err := s.api.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{RequestItems: deleteBatch})
+			if err != nil {
+				return fmt.Errorf("error deleting page %d of deployments for application %s: %w", page, applicationId, err)
+			}
+			deleteBatch = batchWriteOut.UnprocessedItems
+		}
+		queryIn.ExclusiveStartKey = queryOut.LastEvaluatedKey
+	}
+
+	return nil
+}
+
+func batchDeletes(tableName string, items []map[string]types.AttributeValue) map[string][]types.WriteRequest {
+	var deleteBatch []types.WriteRequest
+	for _, item := range items {
+		deleteBatch = append(deleteBatch, types.WriteRequest{
+			DeleteRequest: &types.DeleteRequest{Key: item},
+		})
+	}
+	return map[string][]types.WriteRequest{tableName: deleteBatch}
 }

--- a/fargate/app-provisioner/provisioner/store_dynamodb/deployments_store_test.go
+++ b/fargate/app-provisioner/provisioner/store_dynamodb/deployments_store_test.go
@@ -1,0 +1,130 @@
+package store_dynamodb
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type ArgCaptureDeploymentsTableAPI struct {
+	// Don't save pointers to inputs; make defensive copies instead
+	UpdateItemInput      dynamodb.UpdateItemInput
+	BatchWriteItemInputs []dynamodb.BatchWriteItemInput
+
+	// Query may be paginated, so one DeleteApplicationDeployments call may result in multiple Query calls.
+	// Set QueryOutputs before calling DeleteApplicationDeployments to control how many times Query is called.
+	QueryOutputs            []*dynamodb.QueryOutput
+	currentQueryOutputIndex int
+	// Check QueryInputs after calling DeleteApplicationDeployments to see if we sent the correct inputs.
+	QueryInputs []dynamodb.QueryInput
+}
+
+func (a *ArgCaptureDeploymentsTableAPI) BatchWriteItem(_ context.Context, params *dynamodb.BatchWriteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error) {
+	a.BatchWriteItemInputs = append(a.BatchWriteItemInputs, *params)
+	return &dynamodb.BatchWriteItemOutput{}, nil
+}
+
+func (a *ArgCaptureDeploymentsTableAPI) UpdateItem(_ context.Context, params *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	a.UpdateItemInput = *params
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func (a *ArgCaptureDeploymentsTableAPI) Query(_ context.Context, params *dynamodb.QueryInput, _ ...func(options *dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	a.QueryInputs = append(a.QueryInputs, *params)
+	if a.currentQueryOutputIndex < len(a.QueryOutputs) {
+		output := a.QueryOutputs[a.currentQueryOutputIndex]
+		a.currentQueryOutputIndex++
+		return output, nil
+	}
+	return nil, fmt.Errorf("query called too many times! Expected %d calls", len(a.QueryOutputs))
+
+}
+
+func TestDeploymentsStore_DeleteApplicationDeployments(t *testing.T) {
+	argCaptureAPI := new(ArgCaptureDeploymentsTableAPI)
+	tableName := uuid.NewString()
+	applicationId := uuid.NewString()
+	expectedDeploymentItems := []map[string]types.AttributeValue{
+		deploymentKeyItem(applicationId, uuid.NewString()),
+		deploymentKeyItem(applicationId, uuid.NewString()),
+		deploymentKeyItem(applicationId, uuid.NewString()),
+	}
+	argCaptureAPI.QueryOutputs = []*dynamodb.QueryOutput{
+		{
+			Count:            1,
+			Items:            []map[string]types.AttributeValue{expectedDeploymentItems[0]},
+			LastEvaluatedKey: expectedDeploymentItems[0],
+			ScannedCount:     1,
+		},
+		{
+			Count:            1,
+			Items:            []map[string]types.AttributeValue{expectedDeploymentItems[1]},
+			LastEvaluatedKey: expectedDeploymentItems[1],
+			ScannedCount:     1,
+		},
+		{
+			Count:            1,
+			Items:            []map[string]types.AttributeValue{expectedDeploymentItems[2]},
+			LastEvaluatedKey: nil,
+			ScannedCount:     1,
+		},
+	}
+	store := NewDeploymentsStore(argCaptureAPI, tableName)
+	err := store.DeleteApplicationDeployments(context.Background(), applicationId)
+	require.NoError(t, err)
+
+	assert.Len(t, argCaptureAPI.QueryInputs, len(expectedDeploymentItems))
+
+	for i := range argCaptureAPI.QueryInputs {
+		input := argCaptureAPI.QueryInputs[i]
+		assert.Equal(t, tableName, aws.ToString(input.TableName))
+		if i == 0 {
+			assert.Empty(t, input.ExclusiveStartKey)
+		} else {
+			assert.Equal(t, expectedDeploymentItems[i-1], input.ExclusiveStartKey)
+		}
+		// Names
+		assert.Len(t, input.ExpressionAttributeNames, 2)
+		var deploymentIdNameKey, appIdNameKey string
+		for k, v := range input.ExpressionAttributeNames {
+			if DeploymentApplicationIdField == v {
+				appIdNameKey = k
+			} else if DeploymentIdField == v {
+				deploymentIdNameKey = k
+			} else {
+				assert.Fail(t, "unexpected value in ExpressionAttributeNames", v)
+			}
+		}
+		assert.NotEmpty(t, appIdNameKey)
+		assert.NotEmpty(t, deploymentIdNameKey)
+
+		//Values
+		var appIdValueKey string
+		for k, v := range input.ExpressionAttributeValues {
+			if assert.Equal(t, &types.AttributeValueMemberS{Value: applicationId}, v) {
+				appIdValueKey = k
+			}
+		}
+		assert.NotEmpty(t, appIdValueKey)
+
+		//Key expression
+		assert.Equal(t, fmt.Sprintf("%s = %s", appIdNameKey, appIdValueKey), aws.ToString(input.KeyConditionExpression))
+
+		//Projection expression
+		assert.Equal(t, fmt.Sprintf("%s, %s", deploymentIdNameKey, appIdNameKey), aws.ToString(input.ProjectionExpression))
+
+	}
+}
+
+func deploymentKeyItem(applicationId, deploymentId string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		DeploymentApplicationIdField: &types.AttributeValueMemberS{Value: applicationId},
+		DeploymentIdField:            &types.AttributeValueMemberS{Value: deploymentId},
+	}
+}

--- a/lambda/service/handler/delete_application_handler.go
+++ b/lambda/service/handler/delete_application_handler.go
@@ -47,6 +47,7 @@ func DeleteApplicationHandler(ctx context.Context, request events.APIGatewayV2HT
 
 	dynamoDBClient := dynamodb.NewFromConfig(cfg)
 	applicationsTable := os.Getenv("APPLICATIONS_TABLE")
+	deploymentsTable := os.Getenv(deploymentsTableNameKey)
 
 	applicationIdKey := "APPLICATION_UUID"
 
@@ -142,6 +143,10 @@ func DeleteApplicationHandler(ctx context.Context, request events.APIGatewayV2HT
 						{
 							Name:  &sourceUrlKey,
 							Value: &sourceUrlValue,
+						},
+						{
+							Name:  aws.String(deploymentsTableNameKey),
+							Value: aws.String(deploymentsTable),
 						},
 					},
 				},


### PR DESCRIPTION
Currently when an Application is deleted we delete the associated infrastructure as well as the application record in the Applications DynamoDB table. But we leave the application's deployment records in the Deployments DynamoDB table.

This PR fixes this by also deleting all deployment records associated with the deleted application.

It also uses Pusher to send a new event type, `application_deletion_event`, on the application's channel to notify the frontend of the application's deletion. This event looks like:
```
{
  "application_id" : string, the application uuid
  "time": string, the time of the deletion
  "source": string, source of event. Maybe useful in debugging?
}
```