### PR TITLE
feature: adds a GET AppStore application endpoint

### DIFF
--- a/lambda/service/handler/get_appstore_application_handler.go
+++ b/lambda/service/handler/get_appstore_application_handler.go
@@ -1,0 +1,148 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/pennsieve/app-deploy-service/service/mappers"
+	"github.com/pennsieve/app-deploy-service/service/models"
+	"github.com/pennsieve/app-deploy-service/service/store_dynamodb"
+	ghsync "github.com/pennsieve/github-client/pkg/github/sync"
+	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
+)
+
+func GetAppstoreApplicationHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	handlerName := "GetAppstoreApplicationHandler"
+
+	appId := request.PathParameters["id"]
+	if appId == "" {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusBadRequest,
+			Body:       handlerError(handlerName, ErrMissingParams),
+		}, nil
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		log.Println(err.Error())
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       handlerError(handlerName, ErrConfig),
+		}, nil
+	}
+
+	dynamoDBClient := dynamodb.NewFromConfig(cfg)
+	appStoreStore := store_dynamodb.NewAppStoreDatabaseStore(dynamoDBClient, os.Getenv(appstoreApplicationsTableNameKey))
+	versionStore := store_dynamodb.NewAppStoreVersionDatabaseStore(dynamoDBClient, os.Getenv(appstoreVersionsTableNameKey))
+	deploymentsStore := store_dynamodb.NewDeploymentsStore(dynamoDBClient, os.Getenv(deploymentsTableNameKey))
+	appAccessStore := store_dynamodb.NewAppAccessDatabaseStore(dynamoDBClient, os.Getenv(appAccessTableNameKey))
+
+	app, err := appStoreStore.GetById(ctx, appId)
+	if err != nil {
+		log.Println(err.Error())
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       handlerError(handlerName, ErrDynamoDB),
+		}, nil
+	}
+	if app == nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusNotFound,
+			Body:       handlerError(handlerName, ErrAppNotFound),
+		}, nil
+	}
+
+	claims := authorizer.ParseClaims(request.RequestContext.Authorizer.Lambda)
+	log.Printf("%s: caller org=%s user=%s", handlerName, claims.OrgClaim.NodeId, claims.UserClaim.NodeId)
+
+	if !CanAccessApp(ctx, claims, app, appAccessStore) {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusForbidden,
+			Body:       handlerError(handlerName, ErrNotPermitted),
+		}, nil
+	}
+
+	application := mappers.AppStoreAppToModel(*app)
+
+	dynamoVersions, err := versionStore.GetByApplicationId(ctx, application.Uuid)
+	if err != nil {
+		log.Printf("error fetching versions for application %s: %v", application.Uuid, err)
+	} else {
+		versions := mappers.AppStoreVersionsToModels(dynamoVersions)
+		for j := range versions {
+			deployments, err := deploymentsStore.GetHistory(ctx, versions[j].Uuid)
+			if err != nil {
+				log.Printf("error fetching deployments for version %s: %v", versions[j].Uuid, err)
+				continue
+			}
+			versions[j].Deployments = mappers.DeploymentItemsToModels(deployments)
+		}
+		application.Versions = versions
+	}
+
+	tag := request.QueryStringParameters["tag"]
+	if tag == "" {
+		tag = "main"
+	}
+
+	assets := fetchAssets(ctx, cfg, app.SourceUrl, tag)
+
+	detail := models.AppStoreApplicationDetail{
+		Uuid:       application.Uuid,
+		SourceUrl:  application.SourceUrl,
+		SourceType: application.SourceType,
+		IsPrivate:  application.IsPrivate,
+		Visibility: application.Visibility,
+		OwnerId:    application.OwnerId,
+		CreatedAt:  application.CreatedAt,
+		Versions:   application.Versions,
+		Assets:     assets,
+	}
+
+	m, err := json.Marshal(detail)
+	if err != nil {
+		log.Println(err.Error())
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       handlerError(handlerName, ErrMarshaling),
+		}, nil
+	}
+
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: http.StatusOK,
+		Body:       string(m),
+	}, nil
+}
+
+func fetchAssets(ctx context.Context, cfg aws.Config, sourceUrl string, tag string) map[string]string {
+	bucket := os.Getenv("CONTENT_SYNC_BUCKET")
+	if bucket == "" {
+		log.Println("warning: CONTENT_SYNC_BUCKET not set, skipping asset fetch")
+		return map[string]string{}
+	}
+
+	namespace := buildNamespace(sourceUrl, tag)
+	s3Client := s3.NewFromConfig(cfg)
+	dest := ghsync.NewS3Destination(s3Client, bucket)
+
+	assets := map[string]string{}
+	for _, file := range getSyncFiles() {
+		key := namespace + "/" + file
+		data, _, err := dest.Read(ctx, key)
+		if err != nil {
+			log.Printf("asset %s not found: %v", file, err)
+			continue
+		}
+		assets[file] = string(data)
+	}
+
+	return assets
+}

--- a/lambda/service/handler/get_appstore_application_handler.go
+++ b/lambda/service/handler/get_appstore_application_handler.go
@@ -90,7 +90,7 @@ func GetAppstoreApplicationHandler(ctx context.Context, request events.APIGatewa
 
 	tag := request.QueryStringParameters["tag"]
 	if tag == "" {
-		tag = "main"
+		tag = latestVersionTag(application.Versions)
 	}
 
 	assets := fetchAssets(ctx, cfg, app.SourceUrl, tag)
@@ -120,6 +120,26 @@ func GetAppstoreApplicationHandler(ctx context.Context, request events.APIGatewa
 		StatusCode: http.StatusOK,
 		Body:       string(m),
 	}, nil
+}
+
+// latestVersionTag returns the Version tag of the most recently created version,
+// or "main" if there are no versions.
+func latestVersionTag(versions []models.AppStoreVersion) string {
+	latest := ""
+	latestCreatedAt := ""
+	for _, v := range versions {
+		if v.Version == "" {
+			continue
+		}
+		if v.CreatedAt > latestCreatedAt {
+			latestCreatedAt = v.CreatedAt
+			latest = v.Version
+		}
+	}
+	if latest == "" {
+		return "main"
+	}
+	return latest
 }
 
 func fetchAssets(ctx context.Context, cfg aws.Config, sourceUrl string, tag string) map[string]string {

--- a/lambda/service/handler/get_appstore_application_handler.go
+++ b/lambda/service/handler/get_appstore_application_handler.go
@@ -93,7 +93,10 @@ func GetAppstoreApplicationHandler(ctx context.Context, request events.APIGatewa
 		tag = latestVersionTag(application.Versions)
 	}
 
-	assets := fetchAssets(ctx, cfg, app.SourceUrl, tag)
+	assets := map[string]string{}
+	if tag != "" {
+		assets = fetchAssets(ctx, cfg, app.SourceUrl, tag)
+	}
 
 	detail := models.AppStoreApplicationDetail{
 		Uuid:       application.Uuid,
@@ -123,7 +126,8 @@ func GetAppstoreApplicationHandler(ctx context.Context, request events.APIGatewa
 }
 
 // latestVersionTag returns the Version tag of the most recently created version,
-// or "main" if there are no versions.
+// or an empty string if there are no versions with a tag. Assets are only synced
+// for release tags, so there is no meaningful default when no release exists.
 func latestVersionTag(versions []models.AppStoreVersion) string {
 	latest := ""
 	latestCreatedAt := ""
@@ -135,9 +139,6 @@ func latestVersionTag(versions []models.AppStoreVersion) string {
 			latestCreatedAt = v.CreatedAt
 			latest = v.Version
 		}
-	}
-	if latest == "" {
-		return "main"
 	}
 	return latest
 }

--- a/lambda/service/handler/get_appstore_application_handler_test.go
+++ b/lambda/service/handler/get_appstore_application_handler_test.go
@@ -1,0 +1,68 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAppstoreApplicationHandler_MissingId(t *testing.T) {
+	request := events.APIGatewayV2HTTPRequest{
+		PathParameters: map[string]string{},
+	}
+
+	resp, err := GetAppstoreApplicationHandler(t.Context(), request)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestGetAppstoreApplicationHandler_EmptyId(t *testing.T) {
+	request := events.APIGatewayV2HTTPRequest{
+		PathParameters: map[string]string{"id": ""},
+	}
+
+	resp, err := GetAppstoreApplicationHandler(t.Context(), request)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestGetAppstoreApplicationHandler_DynamoDBError(t *testing.T) {
+	t.Setenv("APPSTORE_APPLICATIONS_TABLE", "nonexistent-table")
+	t.Setenv("APPSTORE_VERSIONS_TABLE", "nonexistent-table")
+	t.Setenv("DEPLOYMENTS_TABLE", "nonexistent-table")
+	t.Setenv("APP_ACCESS_TABLE", "nonexistent-table")
+
+	request := events.APIGatewayV2HTTPRequest{
+		PathParameters: map[string]string{"id": "some-uuid"},
+	}
+
+	resp, err := GetAppstoreApplicationHandler(t.Context(), request)
+	assert.NoError(t, err)
+	assert.True(t, resp.StatusCode >= 400)
+}
+
+func TestFetchAssets_NoBucket(t *testing.T) {
+	t.Setenv("CONTENT_SYNC_BUCKET", "")
+
+	assets := fetchAssets(t.Context(), aws.Config{}, "https://github.com/org/repo", "main")
+	assert.Empty(t, assets)
+}
+
+func TestFetchAssets_WithBucketNoS3(t *testing.T) {
+	t.Setenv("CONTENT_SYNC_BUCKET", "test-bucket")
+	t.Setenv("CONTENT_SYNC_FILES", "pennsieve.json,README.md")
+
+	assets := fetchAssets(t.Context(), aws.Config{}, "https://github.com/org/repo", "main")
+	// S3 calls will fail, so no assets returned
+	assert.Empty(t, assets)
+}
+
+func TestFetchAssets_CustomSyncFiles(t *testing.T) {
+	t.Setenv("CONTENT_SYNC_BUCKET", "test-bucket")
+	t.Setenv("CONTENT_SYNC_FILES", "custom.json")
+
+	assets := fetchAssets(t.Context(), aws.Config{}, "https://github.com/org/repo", "v1.0.0")
+	assert.Empty(t, assets)
+}

--- a/lambda/service/handler/get_appstore_application_handler_test.go
+++ b/lambda/service/handler/get_appstore_application_handler_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/pennsieve/app-deploy-service/service/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,4 +66,41 @@ func TestFetchAssets_CustomSyncFiles(t *testing.T) {
 
 	assets := fetchAssets(t.Context(), aws.Config{}, "https://github.com/org/repo", "v1.0.0")
 	assert.Empty(t, assets)
+}
+
+func TestLatestVersionTag_NoVersions(t *testing.T) {
+	assert.Equal(t, "main", latestVersionTag(nil))
+	assert.Equal(t, "main", latestVersionTag([]models.AppStoreVersion{}))
+}
+
+func TestLatestVersionTag_PicksMostRecentCreatedAt(t *testing.T) {
+	versions := []models.AppStoreVersion{
+		{Version: "v1.0.0", CreatedAt: "2026-01-01"},
+		{Version: "v2.0.0", CreatedAt: "2026-03-15"},
+		{Version: "v1.5.0", CreatedAt: "2026-02-10"},
+	}
+	assert.Equal(t, "v2.0.0", latestVersionTag(versions))
+}
+
+func TestLatestVersionTag_SkipsEmptyVersionString(t *testing.T) {
+	versions := []models.AppStoreVersion{
+		{Version: "", CreatedAt: "2026-04-01"},
+		{Version: "v1.0.0", CreatedAt: "2026-01-01"},
+	}
+	assert.Equal(t, "v1.0.0", latestVersionTag(versions))
+}
+
+func TestLatestVersionTag_AllEmptyVersionsFallsBackToMain(t *testing.T) {
+	versions := []models.AppStoreVersion{
+		{Version: "", CreatedAt: "2026-04-01"},
+		{Version: "", CreatedAt: "2026-01-01"},
+	}
+	assert.Equal(t, "main", latestVersionTag(versions))
+}
+
+func TestLatestVersionTag_SingleVersion(t *testing.T) {
+	versions := []models.AppStoreVersion{
+		{Version: "v0.1.0", CreatedAt: "2026-02-01"},
+	}
+	assert.Equal(t, "v0.1.0", latestVersionTag(versions))
 }

--- a/lambda/service/handler/get_appstore_application_handler_test.go
+++ b/lambda/service/handler/get_appstore_application_handler_test.go
@@ -69,8 +69,8 @@ func TestFetchAssets_CustomSyncFiles(t *testing.T) {
 }
 
 func TestLatestVersionTag_NoVersions(t *testing.T) {
-	assert.Equal(t, "main", latestVersionTag(nil))
-	assert.Equal(t, "main", latestVersionTag([]models.AppStoreVersion{}))
+	assert.Equal(t, "", latestVersionTag(nil))
+	assert.Equal(t, "", latestVersionTag([]models.AppStoreVersion{}))
 }
 
 func TestLatestVersionTag_PicksMostRecentCreatedAt(t *testing.T) {
@@ -90,12 +90,12 @@ func TestLatestVersionTag_SkipsEmptyVersionString(t *testing.T) {
 	assert.Equal(t, "v1.0.0", latestVersionTag(versions))
 }
 
-func TestLatestVersionTag_AllEmptyVersionsFallsBackToMain(t *testing.T) {
+func TestLatestVersionTag_AllEmptyVersionsReturnsEmpty(t *testing.T) {
 	versions := []models.AppStoreVersion{
 		{Version: "", CreatedAt: "2026-04-01"},
 		{Version: "", CreatedAt: "2026-01-01"},
 	}
-	assert.Equal(t, "main", latestVersionTag(versions))
+	assert.Equal(t, "", latestVersionTag(versions))
 }
 
 func TestLatestVersionTag_SingleVersion(t *testing.T) {

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -40,7 +40,6 @@ func AppDeployServiceHandler(ctx context.Context, request events.APIGatewayV2HTT
 
 	// AppStore routes
 	router.POST("/store", PostAppStoreHandler)
-	router.POST("/applications/store", PostAppStoreHandler) // internal invocation (temporary)
 	router.GET("/store", GetAppstoreApplicationsHandler)
 	router.GET("/store/authorize", GetAppStoreAuthorizeHandler)
 

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -44,6 +44,9 @@ func AppDeployServiceHandler(ctx context.Context, request events.APIGatewayV2HTT
 	router.GET("/store", GetAppstoreApplicationsHandler)
 	router.GET("/store/authorize", GetAppStoreAuthorizeHandler)
 
+	// AppStore application detail route
+	router.GET("/store/{id}", GetAppstoreApplicationHandler)
+
 	// AppStore content routes
 	router.GET("/store/{id}/content", GetAppStoreContentHandler)
 

--- a/lambda/service/handler/handler_test.go
+++ b/lambda/service/handler/handler_test.go
@@ -41,6 +41,7 @@ func newTestRouter() Router {
 	router.POST("/store", stubHandler)
 	router.GET("/store", stubHandler)
 	router.GET("/store/authorize", stubHandler)
+	router.GET("/store/{id}", stubHandler)
 	router.GET("/store/{id}/permissions", stubHandler)
 	router.PUT("/store/{id}/permissions", stubHandler)
 	return router
@@ -93,6 +94,9 @@ func TestRouteMatching(t *testing.T) {
 		{"POST store", "POST", "POST /store", "/store", nil},
 		{"GET store", "GET", "GET /store", "/store", nil},
 		{"GET store authorize", "GET", "GET /store/authorize", "/store/authorize", nil},
+
+		// appstore application detail route
+		{"GET store app by id", "GET", "GET /store/{id}", "/store/123", map[string]string{"id": "123"}},
 
 		// appstore permission routes
 		{"GET store permissions", "GET", "GET /store/{id}/permissions", "/store/123/permissions", map[string]string{"id": "123"}},

--- a/lambda/service/handler/post_appstore_handler.go
+++ b/lambda/service/handler/post_appstore_handler.go
@@ -76,7 +76,7 @@ func PostAppStoreHandler(ctx context.Context, request events.APIGatewayV2HTTPReq
 		userId = claims.UserClaim.NodeId
 	} else {
 		log.Println("direct invocation detected, skipping authorization")
-		userId = "system"
+		userId = application.Source.Owner
 	}
 
 	dynamoDBClient := dynamodb.NewFromConfig(cfg)

--- a/lambda/service/models/application.go
+++ b/lambda/service/models/application.go
@@ -1,25 +1,25 @@
 package models
 
 type Application struct {
-	Uuid                     string               `json:"uuid"`
-	ApplicationId            string               `json:"applicationId"`
-	ApplicationContainerName string               `json:"applicationContainerName"`
-	Name                     string               `json:"name"`
-	Description              string               `json:"description"`
-	RuntimeConfig            RuntimeConfig        `json:"runtimeConfig"`
-	Account                  Account              `json:"account"`
-	ComputeNode              ComputeNode          `json:"computeNode"`
-	Source                   Source               `json:"source"`
-	Destination              Destination          `json:"destination"`
-	ApplicationType          string               `json:"applicationType"`
-	Env                      string               `json:"environment"`
-	OrganizationId           string               `json:"organizationId"`
-	UserId                   string               `json:"userId"`
-	CreatedAt                string               `json:"createdAt"`
-	Params                   interface{}          `json:"params,omitempty"`
-	CommandArguments         interface{}          `json:"commandArguments,omitempty"`
-	Deployments              []Deployment         `json:"deployments"`
-	Status                   string               `json:"status"`
+	Uuid                     string        `json:"uuid"`
+	ApplicationId            string        `json:"applicationId"`
+	ApplicationContainerName string        `json:"applicationContainerName"`
+	Name                     string        `json:"name"`
+	Description              string        `json:"description"`
+	RuntimeConfig            RuntimeConfig `json:"runtimeConfig"`
+	Account                  Account       `json:"account"`
+	ComputeNode              ComputeNode   `json:"computeNode"`
+	Source                   Source        `json:"source"`
+	Destination              Destination   `json:"destination"`
+	ApplicationType          string        `json:"applicationType"`
+	Env                      string        `json:"environment"`
+	OrganizationId           string        `json:"organizationId"`
+	UserId                   string        `json:"userId"`
+	CreatedAt                string        `json:"createdAt"`
+	Params                   interface{}   `json:"params,omitempty"`
+	CommandArguments         interface{}   `json:"commandArguments,omitempty"`
+	Deployments              []Deployment  `json:"deployments"`
+	Status                   string        `json:"status"`
 }
 
 type AppStoreDeployment struct {
@@ -44,6 +44,7 @@ type DeploymentSource struct {
 	Tag        string `json:"tag"`
 	IsPrivate  bool   `json:"isPrivate,omitempty"`
 	AuthToken  string `json:"authToken,omitempty"`
+	Owner      string `json:"owner,omitempty"`
 }
 
 type Source struct {

--- a/lambda/service/models/application.go
+++ b/lambda/service/models/application.go
@@ -138,6 +138,18 @@ type AppStoreVersion struct {
 	Deployments    []Deployment `json:"deployments"`
 }
 
+type AppStoreApplicationDetail struct {
+	Uuid       string            `json:"uuid"`
+	SourceUrl  string            `json:"sourceUrl"`
+	SourceType string            `json:"sourceType"`
+	IsPrivate  bool              `json:"isPrivate"`
+	Visibility string            `json:"visibility"`
+	OwnerId    string            `json:"ownerId"`
+	CreatedAt  string            `json:"createdAt"`
+	Versions   []AppStoreVersion `json:"versions"`
+	Assets     map[string]string `json:"assets"`
+}
+
 // AuthorizeImageResponse is returned by the authorization endpoint.
 type AuthorizeImageResponse struct {
 	Authorized bool   `json:"authorized"`

--- a/terraform/app-deploy-service.yml
+++ b/terraform/app-deploy-service.yml
@@ -232,6 +232,35 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AppStoreVersion'
+    AppStoreApplicationDetail:
+      type: object
+      properties:
+        uuid:
+          type: string
+        sourceUrl:
+          type: string
+        sourceType:
+          type: string
+        isPrivate:
+          type: boolean
+        visibility:
+          type: string
+        ownerId:
+          type: string
+        createdAt:
+          type: string
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppStoreVersion'
+        assets:
+          type: object
+          additionalProperties:
+            type: string
+          description: >
+            Map of asset filename to content string. Includes files like
+            pennsieve.json and README.md when they exist in the synced
+            repository content.
     AuthorizeImageResponse:
       type: object
       properties:
@@ -609,6 +638,51 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '4XX':
           $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+  /store/{id}:
+    get:
+      summary: Get app store application
+      description: >
+        Get a single app store application by ID, including its versions,
+        deployment history, and repository assets (e.g. pennsieve.json,
+        README.md) when available.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/app-deploy-service'
+      operationId: getAppStoreApplication
+      security:
+        - token_auth: []
+      tags:
+        - App Store
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The app store application UUID
+        - in: query
+          name: tag
+          required: false
+          schema:
+            type: string
+          description: The branch or tag to retrieve assets from (defaults to main)
+      responses:
+        '200':
+          description: The app store application with versions, deployments, and assets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppStoreApplicationDetail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '5XX':
           $ref: '#/components/responses/Error'
   /store/authorize:

--- a/terraform/app-deploy-service.yml
+++ b/terraform/app-deploy-service.yml
@@ -667,7 +667,10 @@ paths:
           required: false
           schema:
             type: string
-          description: The branch or tag to retrieve assets from (defaults to main)
+          description: >
+            The branch or tag to retrieve assets from. When omitted, defaults
+            to the most recently created version's tag, falling back to "main"
+            if the application has no versions.
       responses:
         '200':
           description: The app store application with versions, deployments, and assets

--- a/terraform/app-deploy-service.yml
+++ b/terraform/app-deploy-service.yml
@@ -668,9 +668,10 @@ paths:
           schema:
             type: string
           description: >
-            The branch or tag to retrieve assets from. When omitted, defaults
-            to the most recently created version's tag, falling back to "main"
-            if the application has no versions.
+            The release tag to retrieve assets from. When omitted, defaults to
+            the most recently created version's tag. If the application has no
+            versions, assets are not fetched and an empty assets map is
+            returned.
       responses:
         '200':
           description: The app store application with versions, deployments, and assets


### PR DESCRIPTION
- Implemented the GET /store/{id} endpoint that returns an app store application with    
  versions, deployments, and GitHub assets in a single response
  
Assets retrieval logic:
  Behavior:
  - ?tag=X → still uses X (override preserved).
  - No ?tag=, versions exist → uses the most recently created version's Version as the tag.
  
A content endpoint that retrieves a specific file for a specific tag also exists. The scale implications of returning all assets per version is not feasible/practical.  