### PR TITLE
fix: refactor/rename authorize endpoint

### DIFF
--- a/lambda/service/handler/get_appstore_application_handler_test.go
+++ b/lambda/service/handler/get_appstore_application_handler_test.go
@@ -53,7 +53,7 @@ func TestFetchAssets_NoBucket(t *testing.T) {
 
 func TestFetchAssets_WithBucketNoS3(t *testing.T) {
 	t.Setenv("CONTENT_SYNC_BUCKET", "test-bucket")
-	t.Setenv("CONTENT_SYNC_FILES", "pennsieve.json,README.md")
+	t.Setenv("CONTENT_SYNC_FILES", "application.json,README.md")
 
 	assets := fetchAssets(t.Context(), aws.Config{}, "https://github.com/org/repo", "main")
 	// S3 calls will fail, so no assets returned

--- a/lambda/service/handler/get_appstore_content_handler_test.go
+++ b/lambda/service/handler/get_appstore_content_handler_test.go
@@ -24,7 +24,7 @@ func TestGetAppStoreContentHandler_MissingBucket(t *testing.T) {
 
 	request := events.APIGatewayV2HTTPRequest{
 		PathParameters:        map[string]string{"id": "some-uuid"},
-		QueryStringParameters: map[string]string{"file": "pennsieve.json"},
+		QueryStringParameters: map[string]string{"file": "application.json"},
 	}
 
 	resp, err := GetAppStoreContentHandler(t.Context(), request)

--- a/lambda/service/handler/get_appstore_registry_handler.go
+++ b/lambda/service/handler/get_appstore_registry_handler.go
@@ -15,16 +15,17 @@ import (
 	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 )
 
-// GetAppStoreAuthorizeHandler checks whether a user is authorized to pull
-// a specific appstore image and returns the ECR image URL.
+// GetAppStoreRegistryHandler resolves an appstore image URL for an authorized
+// caller. Acts as the registry lookup endpoint; will be fronted by a docker
+// proxy in a future iteration.
 // This endpoint is called by Account B's Workflow Manager during cross-account
 // ECR pull workflows.
 //
 // Query parameters:
 //   - sourceUrl: the git repository URL identifying the application
 //   - version: the specific version tag (e.g., "v1.0.7")
-func GetAppStoreAuthorizeHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
-	handlerName := "GetAppStoreAuthorizeHandler"
+func GetAppStoreRegistryHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	handlerName := "GetAppStoreRegistryHandler"
 
 	sourceUrl := request.QueryStringParameters["sourceUrl"]
 	version := request.QueryStringParameters["version"]
@@ -63,7 +64,7 @@ func GetAppStoreAuthorizeHandler(ctx context.Context, request events.APIGatewayV
 	}
 
 	if len(apps) == 0 {
-		resp := models.AuthorizeImageResponse{
+		resp := models.RegistryImageResponse{
 			Authorized: false,
 			Message:    "application not found in app store",
 		}
@@ -85,7 +86,7 @@ func GetAppStoreAuthorizeHandler(ctx context.Context, request events.APIGatewayV
 	}
 
 	if len(versions) == 0 {
-		resp := models.AuthorizeImageResponse{
+		resp := models.RegistryImageResponse{
 			Authorized: false,
 			Message:    "version not found for this application",
 		}
@@ -98,7 +99,7 @@ func GetAppStoreAuthorizeHandler(ctx context.Context, request events.APIGatewayV
 
 	ver := versions[0]
 	if ver.DestinationUrl == "" || ver.Status != "deployed" {
-		resp := models.AuthorizeImageResponse{
+		resp := models.RegistryImageResponse{
 			Authorized: false,
 			Message:    "version is not yet deployed",
 		}
@@ -114,7 +115,7 @@ func GetAppStoreAuthorizeHandler(ctx context.Context, request events.APIGatewayV
 	appAccessStore := store_dynamodb.NewAppAccessDatabaseStore(dynamoDBClient, appAccessTable)
 
 	if !CanAccessApp(ctx, claims, &apps[0], appAccessStore) {
-		resp := models.AuthorizeImageResponse{
+		resp := models.RegistryImageResponse{
 			Authorized: false,
 			Message:    "user does not have access to this application",
 		}
@@ -128,7 +129,7 @@ func GetAppStoreAuthorizeHandler(ctx context.Context, request events.APIGatewayV
 	log.Printf("%s: authorizing image %s (source: %s, version: %s)",
 		handlerName, ver.DestinationUrl, sourceUrl, version)
 
-	resp := models.AuthorizeImageResponse{
+	resp := models.RegistryImageResponse{
 		Authorized: true,
 		ImageUrl:   ver.DestinationUrl,
 	}

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -41,7 +41,7 @@ func AppDeployServiceHandler(ctx context.Context, request events.APIGatewayV2HTT
 	// AppStore routes
 	router.POST("/store", PostAppStoreHandler)
 	router.GET("/store", GetAppstoreApplicationsHandler)
-	router.GET("/store/authorize", GetAppStoreAuthorizeHandler)
+	router.GET("/store/registry", GetAppStoreRegistryHandler)
 
 	// AppStore application detail route
 	router.GET("/store/{id}", GetAppstoreApplicationHandler)

--- a/lambda/service/handler/handler_test.go
+++ b/lambda/service/handler/handler_test.go
@@ -40,7 +40,7 @@ func newTestRouter() Router {
 	router.POST("/deploy", stubHandler)
 	router.POST("/store", stubHandler)
 	router.GET("/store", stubHandler)
-	router.GET("/store/authorize", stubHandler)
+	router.GET("/store/registry", stubHandler)
 	router.GET("/store/{id}", stubHandler)
 	router.GET("/store/{id}/permissions", stubHandler)
 	router.PUT("/store/{id}/permissions", stubHandler)
@@ -93,7 +93,7 @@ func TestRouteMatching(t *testing.T) {
 		// appstore routes
 		{"POST store", "POST", "POST /store", "/store", nil},
 		{"GET store", "GET", "GET /store", "/store", nil},
-		{"GET store authorize", "GET", "GET /store/authorize", "/store/authorize", nil},
+		{"GET store registry", "GET", "GET /store/registry", "/store/registry", nil},
 
 		// appstore application detail route
 		{"GET store app by id", "GET", "GET /store/{id}", "/store/123", map[string]string{"id": "123"}},

--- a/lambda/service/handler/repo_sync.go
+++ b/lambda/service/handler/repo_sync.go
@@ -13,7 +13,7 @@ import (
 	ghsync "github.com/pennsieve/github-client/pkg/github/sync"
 )
 
-var defaultSyncFiles = []string{"pennsieve.json", "README.md"}
+var defaultSyncFiles = []string{"application.json", "README.md"}
 
 func getSyncFiles() []string {
 	if v := os.Getenv("CONTENT_SYNC_FILES"); v != "" {

--- a/lambda/service/handler/repo_sync_test.go
+++ b/lambda/service/handler/repo_sync_test.go
@@ -132,15 +132,15 @@ func TestGetSyncFiles_Default(t *testing.T) {
 }
 
 func TestGetSyncFiles_FromEnv(t *testing.T) {
-	t.Setenv("CONTENT_SYNC_FILES", "pennsieve.json,README.md,CHANGELOG.md")
+	t.Setenv("CONTENT_SYNC_FILES", "application.json,README.md,CHANGELOG.md")
 	files := getSyncFiles()
-	assert.Equal(t, []string{"pennsieve.json", "README.md", "CHANGELOG.md"}, files)
+	assert.Equal(t, []string{"application.json", "README.md", "CHANGELOG.md"}, files)
 }
 
 func TestGetSyncFiles_SingleFile(t *testing.T) {
-	t.Setenv("CONTENT_SYNC_FILES", "pennsieve.json")
+	t.Setenv("CONTENT_SYNC_FILES", "application.json")
 	files := getSyncFiles()
-	assert.Equal(t, []string{"pennsieve.json"}, files)
+	assert.Equal(t, []string{"application.json"}, files)
 }
 
 func TestSyncContent_Integration(t *testing.T) {
@@ -149,7 +149,7 @@ func TestSyncContent_Integration(t *testing.T) {
 
 	mock := &mockGitHubApi{
 		contentMap: map[string]*github.GitHubContentResponse{
-			"https://github.com/org/repo/pennsieve.json/v1.0.0": {
+			"https://github.com/org/repo/application.json/v1.0.0": {
 				Content:  encoded,
 				Encoding: "base64",
 			},
@@ -166,7 +166,7 @@ func TestSyncContent_Integration(t *testing.T) {
 		RepoUrl:   "https://github.com/org/repo",
 		Tag:       "v1.0.0",
 		Namespace: "org/repo/v1.0.0",
-		Files:     []string{"pennsieve.json", "README.md"},
+		Files:     []string{"application.json", "README.md"},
 	}
 
 	results := ghsync.SyncContent(t.Context(), logger, fetcher, config, dest)
@@ -174,6 +174,6 @@ func TestSyncContent_Integration(t *testing.T) {
 		assert.NoError(t, r.Error)
 	}
 
-	assert.Equal(t, []byte(`{"name":"test-app"}`), dest.written["org/repo/v1.0.0/pennsieve.json"])
+	assert.Equal(t, []byte(`{"name":"test-app"}`), dest.written["org/repo/v1.0.0/application.json"])
 	assert.Equal(t, []byte("# Test App"), dest.written["org/repo/v1.0.0/README.md"])
 }

--- a/lambda/service/models/application.go
+++ b/lambda/service/models/application.go
@@ -151,8 +151,8 @@ type AppStoreApplicationDetail struct {
 	Assets     map[string]string `json:"assets"`
 }
 
-// AuthorizeImageResponse is returned by the authorization endpoint.
-type AuthorizeImageResponse struct {
+// RegistryImageResponse is returned by the registry endpoint.
+type RegistryImageResponse struct {
 	Authorized bool   `json:"authorized"`
 	ImageUrl   string `json:"imageUrl,omitempty"`
 	Message    string `json:"message,omitempty"`

--- a/terraform/app-deploy-service.yml
+++ b/terraform/app-deploy-service.yml
@@ -261,7 +261,7 @@ components:
             Map of asset filename to content string. Includes files like
             pennsieve.json and README.md when they exist in the synced
             repository content.
-    AuthorizeImageResponse:
+    RegistryImageResponse:
       type: object
       properties:
         authorized:
@@ -270,7 +270,7 @@ components:
           type: string
         message:
           type: string
-    AuthorizeImageDeniedResponse:
+    RegistryImageDeniedResponse:
       type: object
       properties:
         authorized:
@@ -689,13 +689,13 @@ paths:
           $ref: '#/components/responses/NotFound'
         '5XX':
           $ref: '#/components/responses/Error'
-  /store/authorize:
+  /store/registry:
     get:
-      summary: Authorize app store
-      description: Checks whether a user is authorized to pull a specific appstore image and returns the ECR image URL
+      summary: App store registry lookup
+      description: Resolves the image URL for an appstore application version for an authorized caller.
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/app-deploy-service'
-      operationId: getAppStoreAuthorize
+      operationId: getAppStoreRegistry
       security:
         - token_auth: []
       tags:
@@ -719,7 +719,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthorizeImageResponse'
+                $ref: '#/components/schemas/RegistryImageResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -727,13 +727,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthorizeImageDeniedResponse'
+                $ref: '#/components/schemas/RegistryImageDeniedResponse'
         '404':
           description: Application or version not found, or version not yet deployed
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthorizeImageDeniedResponse'
+                $ref: '#/components/schemas/RegistryImageDeniedResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '4XX':

--- a/terraform/app-deploy-service.yml
+++ b/terraform/app-deploy-service.yml
@@ -259,7 +259,7 @@ components:
             type: string
           description: >
             Map of asset filename to content string. Includes files like
-            pennsieve.json and README.md when they exist in the synced
+            application.json and README.md when they exist in the synced
             repository content.
     RegistryImageResponse:
       type: object
@@ -645,7 +645,7 @@ paths:
       summary: Get app store application
       description: >
         Get a single app store application by ID, including its versions,
-        deployment history, and repository assets (e.g. pennsieve.json,
+        deployment history, and repository assets (e.g. application.json,
         README.md) when available.
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/app-deploy-service'


### PR DESCRIPTION
Minor changes:
- renames authorize endpoint -> registry endpoint
- updates `pennsieve.json` entries to `application.json`