### PR TITLE
fix: create bucket if does not exist

### DIFF
--- a/fargate/app-provisioner/provisioner/aws/aws_provisioner.go
+++ b/fargate/app-provisioner/provisioner/aws/aws_provisioner.go
@@ -2,6 +2,7 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os/exec"
@@ -12,10 +13,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pennsieve/app-deploy-service/app-provisioner/provisioner"
 	"github.com/pennsieve/app-deploy-service/app-provisioner/provisioner/utils"
 )
+
+type s3BackendAPI interface {
+	HeadBucket(ctx context.Context, params *s3.HeadBucketInput, optFns ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
+	CreateBucket(ctx context.Context, params *s3.CreateBucketInput, optFns ...func(*s3.Options)) (*s3.CreateBucketOutput, error)
+	PutBucketVersioning(ctx context.Context, params *s3.PutBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.PutBucketVersioningOutput, error)
+}
 
 type AWSProvisioner struct {
 	Config              aws.Config
@@ -73,26 +81,15 @@ func (p *AWSProvisioner) Create(ctx context.Context) error {
 		return err
 	}
 
-	// check for backend bucket
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.Credentials = credentials.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken)
 	})
-	resp, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
-	if err != nil {
+
+	bucket := fmt.Sprintf("tfstate-%s", p.AccountId)
+	if err := ensureBackendBucket(ctx, client, bucket, cfg.Region); err != nil {
 		return err
 	}
-
-	for _, b := range resp.Buckets {
-		if *b.Name == fmt.Sprintf("tfstate-%s", p.AccountId) {
-			p.BackendExists = true
-			break
-		}
-	}
-
-	if !p.BackendExists {
-		// create s3 backend bucket
-		return fmt.Errorf("expected tfstate-%s to exist", p.AccountId)
-	}
+	p.BackendExists = true
 
 	// create infrastructure
 	runOnGPUStr := strconv.FormatBool(p.RunOnGPU)
@@ -140,6 +137,46 @@ func (p *AWSProvisioner) CreatePublicRepository(ctx context.Context) error {
 	}
 	fmt.Println(string(out))
 
+	return nil
+}
+
+func ensureBackendBucket(ctx context.Context, client s3BackendAPI, bucket, region string) error {
+	_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+	if err == nil {
+		return nil
+	}
+
+	var notFound *s3types.NotFound
+	var noSuchBucket *s3types.NoSuchBucket
+	if !errors.As(err, &notFound) && !errors.As(err, &noSuchBucket) {
+		return fmt.Errorf("checking backend bucket %s: %w", bucket, err)
+	}
+
+	log.Printf("backend bucket %s not found, creating ...", bucket)
+
+	createInput := &s3.CreateBucketInput{Bucket: aws.String(bucket)}
+	if region != "" && region != "us-east-1" {
+		createInput.CreateBucketConfiguration = &s3types.CreateBucketConfiguration{
+			LocationConstraint: s3types.BucketLocationConstraint(region),
+		}
+	}
+	if _, err := client.CreateBucket(ctx, createInput); err != nil {
+		var alreadyOwned *s3types.BucketAlreadyOwnedByYou
+		if !errors.As(err, &alreadyOwned) {
+			return fmt.Errorf("creating backend bucket %s: %w", bucket, err)
+		}
+	}
+
+	if _, err := client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
+		Bucket: aws.String(bucket),
+		VersioningConfiguration: &s3types.VersioningConfiguration{
+			Status: s3types.BucketVersioningStatusEnabled,
+		},
+	}); err != nil {
+		return fmt.Errorf("enabling versioning on %s: %w", bucket, err)
+	}
+
+	log.Printf("backend bucket %s ready", bucket)
 	return nil
 }
 

--- a/fargate/app-provisioner/provisioner/aws/aws_provisioner_test.go
+++ b/fargate/app-provisioner/provisioner/aws/aws_provisioner_test.go
@@ -1,0 +1,135 @@
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+type fakeS3 struct {
+	headErr         error
+	createErr       error
+	versioningErr   error
+	headCalls       int
+	createCalls     int
+	versioningCalls int
+	lastCreateInput *s3.CreateBucketInput
+}
+
+func (f *fakeS3) HeadBucket(ctx context.Context, params *s3.HeadBucketInput, optFns ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	f.headCalls++
+	return &s3.HeadBucketOutput{}, f.headErr
+}
+
+func (f *fakeS3) CreateBucket(ctx context.Context, params *s3.CreateBucketInput, optFns ...func(*s3.Options)) (*s3.CreateBucketOutput, error) {
+	f.createCalls++
+	f.lastCreateInput = params
+	return &s3.CreateBucketOutput{}, f.createErr
+}
+
+func (f *fakeS3) PutBucketVersioning(ctx context.Context, params *s3.PutBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.PutBucketVersioningOutput, error) {
+	f.versioningCalls++
+	return &s3.PutBucketVersioningOutput{}, f.versioningErr
+}
+
+func TestEnsureBackendBucket_BucketExists(t *testing.T) {
+	f := &fakeS3{}
+	if err := ensureBackendBucket(context.Background(), f, "tfstate-123", "us-east-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.headCalls != 1 {
+		t.Errorf("expected 1 HeadBucket call, got %d", f.headCalls)
+	}
+	if f.createCalls != 0 || f.versioningCalls != 0 {
+		t.Errorf("expected no create/configure calls when bucket exists")
+	}
+}
+
+func TestEnsureBackendBucket_CreatesWhenMissing_USEast1(t *testing.T) {
+	f := &fakeS3{headErr: &s3types.NotFound{}}
+	if err := ensureBackendBucket(context.Background(), f, "tfstate-123", "us-east-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.createCalls != 1 {
+		t.Fatalf("expected CreateBucket to be called once, got %d", f.createCalls)
+	}
+	if f.lastCreateInput.CreateBucketConfiguration != nil {
+		t.Errorf("us-east-1 create should not set LocationConstraint")
+	}
+	if f.versioningCalls != 1 {
+		t.Errorf("expected versioning to be called once, got %d", f.versioningCalls)
+	}
+}
+
+func TestEnsureBackendBucket_CreatesWithLocationConstraint(t *testing.T) {
+	f := &fakeS3{headErr: &s3types.NotFound{}}
+	if err := ensureBackendBucket(context.Background(), f, "tfstate-123", "us-west-2"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.lastCreateInput.CreateBucketConfiguration == nil {
+		t.Fatal("expected LocationConstraint for non-us-east-1 region")
+	}
+	if got := string(f.lastCreateInput.CreateBucketConfiguration.LocationConstraint); got != "us-west-2" {
+		t.Errorf("expected LocationConstraint us-west-2, got %s", got)
+	}
+}
+
+func TestEnsureBackendBucket_HandlesNoSuchBucket(t *testing.T) {
+	f := &fakeS3{headErr: &s3types.NoSuchBucket{}}
+	if err := ensureBackendBucket(context.Background(), f, "tfstate-123", "us-east-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.createCalls != 1 {
+		t.Errorf("expected CreateBucket to be called, got %d", f.createCalls)
+	}
+}
+
+func TestEnsureBackendBucket_PropagatesUnexpectedHeadError(t *testing.T) {
+	f := &fakeS3{headErr: errors.New("access denied")}
+	err := ensureBackendBucket(context.Background(), f, "tfstate-123", "us-east-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if f.createCalls != 0 {
+		t.Errorf("expected no CreateBucket call on head error, got %d", f.createCalls)
+	}
+}
+
+func TestEnsureBackendBucket_AlreadyOwnedByYouIsOK(t *testing.T) {
+	f := &fakeS3{
+		headErr:   &s3types.NotFound{},
+		createErr: &s3types.BucketAlreadyOwnedByYou{},
+	}
+	if err := ensureBackendBucket(context.Background(), f, "tfstate-123", "us-east-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.versioningCalls != 1 {
+		t.Errorf("expected versioning to run after already-owned; got %d", f.versioningCalls)
+	}
+}
+
+func TestEnsureBackendBucket_PropagatesCreateError(t *testing.T) {
+	f := &fakeS3{
+		headErr:   &s3types.NotFound{},
+		createErr: errors.New("boom"),
+	}
+	if err := ensureBackendBucket(context.Background(), f, "tfstate-123", "us-east-1"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if f.versioningCalls != 0 {
+		t.Errorf("expected no versioning call on create error")
+	}
+}
+
+func TestEnsureBackendBucket_PropagatesVersioningError(t *testing.T) {
+	f := &fakeS3{
+		headErr:       &s3types.NotFound{},
+		versioningErr: errors.New("boom"),
+	}
+	if err := ensureBackendBucket(context.Background(), f, "tfstate-123", "us-east-1"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
- create bucket if does not exist - this fixes an issue introduced by the recent provisioner changes. Before the compute node managed the creation of buckets related to the node and its applications. The new provisioner no longer provisions the app backend bucket.
- This will be superseded by the new AppStore changes