### PR TITLE
terraform: output appstore-applications-table name/arn

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,3 +17,11 @@ output "applications_table_name" {
 output "applications_table_arn" {
   value = aws_dynamodb_table.applications_table.arn
 }
+
+output "appstore_applications_table_name" {
+  value = aws_dynamodb_table.appstore_applications_table.name
+}
+
+output "appstore_applications_table_arn" {
+  value = aws_dynamodb_table.appstore_applications_table.arn
+}


### PR DESCRIPTION
## Summary
Exposes the **appstore-applications-table** via terraform outputs (`appstore_applications_table_name`, `appstore_applications_table_arn`) so other services can reference it through remote state.

## Why
workflow-service needs read access to this table to check an application's `visibility` column when publishing a public workflow (see Pennsieve/workflow-service `fix/publish-check-app-visibility`).

## Test plan
- [x] `terraform fmt`
- Outputs reference the existing `aws_dynamodb_table.appstore_applications_table` resource.