### PR TITLE
Resolve SOCI-enabled image in appstore registry endpoint

### DIFF
--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.17
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.7.17
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.3
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.41.10
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.9

--- a/lambda/service/go.sum
+++ b/lambda/service/go.sum
@@ -26,6 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.3 h1:idREjl1I4PVmHSeRgwtvA7/
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.3/go.mod h1:uNhUf9Z3MT6Ex+u0ADa8r3MKK5zjuActEfXQPo4YqEI=
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.20.7 h1:TIt7UjRs7Eya0RNILTKoTiQzCFYR+kLOIBovLc0T/7k=
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.20.7/go.mod h1:IL6qnQxrc/qIjwzeg7USP3P7ySEehOPpXJslRbXNYJ4=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3 h1:RtGctYMmkTerGClvdY6bHXdtly4FeYw9wz/NPz62LF8=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3/go.mod h1:vBfBu24Ka3/5UZtepbTV0gnc9VPLT8ok+0oDDaYAzn4=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.41.10 h1:hdACUSUHlhnWwtPk8IGRCfkMhtxjk2AII1B5AuAYryc=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.41.10/go.mod h1:ixRB9qcKi35waDtPb6uw31Eb7Df+MOcjtpWxxPO5XvI=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=

--- a/lambda/service/handler/get_appstore_registry_handler.go
+++ b/lambda/service/handler/get_appstore_registry_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/pennsieve/app-deploy-service/service/models"
 	"github.com/pennsieve/app-deploy-service/service/store_dynamodb"
 	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
@@ -142,9 +143,16 @@ func GetAppStoreRegistryHandler(ctx context.Context, request events.APIGatewayV2
 	log.Printf("%s: authorizing image %s (source: %s, version: %s)",
 		handlerName, ver.DestinationUrl, sourceUrl, version)
 
+	// Prefer the SOCI-enabled image (digest of the "<tag>-soci" manifest) when one
+	// exists, so Fargate lazy-loads the image instead of full-pulling it. Returns
+	// the original URL unchanged when no SOCI index is present. Same-account
+	// lookup (this handler runs in the appstore ECR's account).
+	ecrClient := ecr.NewFromConfig(cfg)
+	imageUrl := resolveAppStoreImageURL(ctx, ecrClient, ver.DestinationUrl)
+
 	resp := models.RegistryImageResponse{
 		Authorized: true,
-		ImageUrl:   ver.DestinationUrl,
+		ImageUrl:   imageUrl,
 	}
 	m, err := json.Marshal(resp)
 	if err != nil {

--- a/lambda/service/handler/image_resolver.go
+++ b/lambda/service/handler/image_resolver.go
@@ -1,0 +1,115 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+)
+
+// SOCI v2 index annotations, as produced by the AWS SOCI Index Builder.
+const (
+	// sociIndexArtifactType is the artifactType of the SOCI v2 ztoc artifact
+	// stored inside the "<tag>-soci" OCI image index.
+	sociIndexArtifactType = "application/vnd.amazon.soci.index.v2+json"
+	// sociImageManifestDigestAnnotation, on the ztoc artifact, names the digest
+	// of the soci-enabled image manifest (the runnable clone of the image
+	// carrying the index-digest link) that must be deployed for Fargate to
+	// lazy-load.
+	sociImageManifestDigestAnnotation = "com.amazon.soci.image-manifest-digest"
+	// sociIndexDigestAnnotation, on the soci-enabled image manifest itself,
+	// links it to its ztoc artifact. Used as a fallback to identify the
+	// runnable manifest.
+	sociIndexDigestAnnotation = "com.amazon.soci.index-digest"
+)
+
+// ecrBatchGetImageAPI is the subset of the ECR client used here (for testing).
+type ecrBatchGetImageAPI interface {
+	BatchGetImage(ctx context.Context, params *ecr.BatchGetImageInput, optFns ...func(*ecr.Options)) (*ecr.BatchGetImageOutput, error)
+}
+
+// resolveAppStoreImageURL returns the image URL to hand back to an authorized
+// caller. When a "<tag>-soci" SOCI v2 index exists for the resolved ECR image,
+// it returns the digest of the soci-enabled image manifest so Fargate (platform
+// version 1.4.0+) lazy-loads the image instead of full-pulling it — the AWS SOCI
+// v2 index builder deliberately does NOT move the original tag, so the only way
+// to engage lazy loading is to deploy the soci-enabled manifest digest.
+//
+// This handler runs in the platform account (same account as the appstore ECR
+// repo and the SOCI index), so the lookup is same-account — no cross-account
+// RegistryId/role needed.
+//
+// The change is surgical: it ONLY overrides the URL when a SOCI index is present
+// (it's built asynchronously after the image push). For non-ECR images, digest
+// pins, missing tags, no SOCI index, or any error, the original URL is returned
+// unchanged.
+func resolveAppStoreImageURL(ctx context.Context, ecrClient ecrBatchGetImageAPI, imageURL string) string {
+	parts := strings.SplitN(imageURL, "/", 2)
+	if len(parts) != 2 || !strings.Contains(parts[0], ".dkr.ecr.") {
+		return imageURL // non-ECR registry or malformed — use as-is
+	}
+	repoAndTag := parts[1]
+	if strings.Contains(repoAndTag, "@") {
+		return imageURL // already a digest pin
+	}
+	idx := strings.LastIndex(repoAndTag, ":")
+	if idx < 0 {
+		return imageURL // no tag to look up
+	}
+	repoName, tag := repoAndTag[:idx], repoAndTag[idx+1:]
+
+	out, err := ecrClient.BatchGetImage(ctx, &ecr.BatchGetImageInput{
+		RepositoryName:     aws.String(repoName),
+		ImageIds:           []ecrtypes.ImageIdentifier{{ImageTag: aws.String(tag + "-soci")}},
+		AcceptedMediaTypes: []string{"application/vnd.oci.image.index.v1+json"},
+	})
+	if err != nil || len(out.Images) == 0 || out.Images[0].ImageManifest == nil {
+		return imageURL // no SOCI index yet — leave the tag as-is
+	}
+
+	sociDigest := sociImageManifestDigest(*out.Images[0].ImageManifest)
+	if sociDigest == "" {
+		return imageURL
+	}
+
+	resolved := fmt.Sprintf("%s/%s@%s", parts[0], repoName, sociDigest)
+	log.Printf("Resolved %s -> %s (SOCI-enabled, Fargate lazy load)", imageURL, resolved)
+	return resolved
+}
+
+// sociImageManifestDigest parses a "<tag>-soci" OCI image index and returns the
+// digest of the soci-enabled image manifest to deploy. Returns "" if it can't be
+// determined (caller falls back to the original image URL).
+func sociImageManifestDigest(manifestJSON string) string {
+	var index struct {
+		Manifests []struct {
+			ArtifactType string            `json:"artifactType"`
+			Digest       string            `json:"digest"`
+			Annotations  map[string]string `json:"annotations"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal([]byte(manifestJSON), &index); err != nil {
+		return ""
+	}
+	// Preferred: the ztoc artifact names the soci-enabled image manifest digest.
+	for _, m := range index.Manifests {
+		if m.ArtifactType == sociIndexArtifactType {
+			if d := m.Annotations[sociImageManifestDigestAnnotation]; d != "" {
+				return d
+			}
+		}
+	}
+	// Fallback: the soci-enabled image manifest is the child (not the ztoc
+	// artifact) carrying the index-digest link to its ztoc.
+	for _, m := range index.Manifests {
+		if m.ArtifactType == "" && m.Annotations[sociIndexDigestAnnotation] != "" {
+			return m.Digest
+		}
+	}
+	return ""
+}

--- a/lambda/service/handler/image_resolver_test.go
+++ b/lambda/service/handler/image_resolver_test.go
@@ -1,0 +1,108 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+)
+
+// fakeECR returns a canned manifest and records the tags it was asked for.
+type fakeECR struct {
+	manifest      string // returned as the image manifest when set
+	err           error  // returned for every call when set
+	requestedTags []string
+}
+
+func (f *fakeECR) BatchGetImage(_ context.Context, in *ecr.BatchGetImageInput, _ ...func(*ecr.Options)) (*ecr.BatchGetImageOutput, error) {
+	tag := ""
+	if len(in.ImageIds) > 0 && in.ImageIds[0].ImageTag != nil {
+		tag = *in.ImageIds[0].ImageTag
+	}
+	f.requestedTags = append(f.requestedTags, tag)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.manifest == "" {
+		return &ecr.BatchGetImageOutput{}, nil // no images found
+	}
+	return &ecr.BatchGetImageOutput{
+		Images: []ecrtypes.Image{{ImageManifest: aws.String(f.manifest)}},
+	}, nil
+}
+
+const sociIndexManifest = `{
+	"mediaType":"application/vnd.oci.image.index.v1+json",
+	"manifests":[
+		{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:127d886","annotations":{"com.amazon.soci.index-digest":"sha256:b75ee60"}},
+		{"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/vnd.amazon.soci.index.v2+json","digest":"sha256:b75ee60","annotations":{"com.amazon.soci.image-manifest-digest":"sha256:127d886"}}
+	]
+}`
+
+func TestResolveAppStoreImageURL(t *testing.T) {
+	const base = "941165240011.dkr.ecr.us-east-1.amazonaws.com/dev-appstore-private-use1"
+	const plainTag = base + ":4101059555-v0.1.3"
+
+	t.Run("soci index present -> soci manifest digest", func(t *testing.T) {
+		f := &fakeECR{manifest: sociIndexManifest}
+		got := resolveAppStoreImageURL(context.Background(), f, plainTag)
+		want := base + "@sha256:127d886"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+		if len(f.requestedTags) != 1 || f.requestedTags[0] != "4101059555-v0.1.3-soci" {
+			t.Fatalf("expected lookup of -soci tag, got %v", f.requestedTags)
+		}
+	})
+
+	t.Run("no soci index -> original tag unchanged", func(t *testing.T) {
+		f := &fakeECR{} // no images
+		if got := resolveAppStoreImageURL(context.Background(), f, plainTag); got != plainTag {
+			t.Fatalf("got %q, want unchanged %q", got, plainTag)
+		}
+	})
+
+	t.Run("ecr error -> original tag unchanged", func(t *testing.T) {
+		f := &fakeECR{err: errors.New("boom")}
+		if got := resolveAppStoreImageURL(context.Background(), f, plainTag); got != plainTag {
+			t.Fatalf("got %q, want unchanged %q", got, plainTag)
+		}
+	})
+
+	t.Run("non-ecr / digest / untagged passthrough (no ECR call)", func(t *testing.T) {
+		for _, in := range []string{
+			"pennsieve/session-proxy:v0.1.0",
+			"docker.io/pennsieve/session-proxy:v0.1.0",
+			base + "@sha256:deadbeef",
+			"python:3.12-slim",
+		} {
+			f := &fakeECR{manifest: sociIndexManifest}
+			if got := resolveAppStoreImageURL(context.Background(), f, in); got != in {
+				t.Errorf("resolveAppStoreImageURL(%q) = %q, want unchanged", in, got)
+			}
+			if len(f.requestedTags) != 0 {
+				t.Errorf("expected no ECR call for %q, got %v", in, f.requestedTags)
+			}
+		}
+	})
+}
+
+func TestSociImageManifestDigest(t *testing.T) {
+	cases := []struct{ name, manifest, want string }{
+		{"preferred ztoc annotation", sociIndexManifest, "sha256:127d886"},
+		{"fallback index-digest", `{"manifests":[{"digest":"sha256:abc","annotations":{"com.amazon.soci.index-digest":"sha256:zzz"}}]}`, "sha256:abc"},
+		{"no soci children", `{"manifests":[{"digest":"sha256:abc"}]}`, ""},
+		{"invalid json", `nope`, ""},
+		{"empty", `{}`, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sociImageManifestDigest(c.manifest); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -158,6 +158,21 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
 
   }
 
+  statement {
+    sid    = "AppStoreRegistryECRRead"
+    effect = "Allow"
+
+    # The registry endpoint (GetAppStoreRegistryHandler) reads image manifests to
+    # resolve the SOCI-enabled image (<tag>-soci) so Fargate lazy-loads it.
+    actions = [
+      "ecr:BatchGetImage",
+    ]
+
+    resources = [
+      "arn:aws:ecr:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:repository/*"
+    ]
+  }
+
 }
 
 # Status Lambda


### PR DESCRIPTION
## Problem

We deployed the AWS SOCI Index Builder so interactive-notebook / processor images get a SOCI index for Fargate lazy loading — but benchmarks showed **no pull-time speedup** (v0.1.3 with a SOCI v2 index pulled in 17.4s vs 11.4s baseline).

Root cause: the SOCI v2 index builder **does not move the original image tag**. It pushes a parallel `<tag>-soci` OCI index that bundles (a) a *soci-enabled* image manifest — a clone of the image carrying the `com.amazon.soci.index-digest` link — and (b) the ztoc artifact. The original tag still resolves to the plain, un-linked manifest, which Fargate **full-pulls**. So lazy loading never engaged even though the index was built correctly. Per AWS, the supported way to engage SOCI v2 is to *deploy the digest of the soci-enabled manifest*.

(Confirmed: Fargate supports SOCI v2 since Jul 2025 and v2 is the default; v1 was discontinued for Fargate on Feb 9, 2026. Platform 1.4.0 — what we run — is correct. So this is purely a "which manifest do we deploy" problem, not a platform/version one.)

## Change

`GetAppStoreRegistryHandler` is the authoritative image resolver — it already authorizes the caller (`CanAccessApp`) and returns the version's ECR image — and it runs in the **platform account** (same account as the appstore ECR repo and the SOCI index), so it can resolve same-account:

- **`handler/image_resolver.go`** (new) — `resolveAppStoreImageURL` looks up `<tag>-soci`; when present, returns the digest of the soci-enabled image manifest so Fargate lazy-loads it. **Surgical:** only overrides when a SOCI index exists. Non-ECR images, digest pins, missing tags, no-index-yet, and any error all return the original URL unchanged, so launches never break (the index is built asynchronously after the image push). Plus `sociImageManifestDigest` (manifest parser).
- **`handler/get_appstore_registry_handler.go`** — resolves `ver.DestinationUrl` through the new function before returning it as `imageUrl`.
- **`terraform/iam.tf`** — added `ecr:BatchGetImage` (scoped to account ECR repos) to the **service lambda role**, which previously had no ECR permissions (the call would have been denied).
- **`go.mod`/`go.sum`** — added `service/ecr`.

Chosen over resolving in the converter (compute-node-aws-provisioner) because this is same-account (no cross-account RegistryId/repo-policy dependency), authoritative, and centralized — every caller of `/applications/store/registry` benefits.

## Tests

`TestResolveAppStoreImageURL` (soci-present → digest, no-index → unchanged, ECR error → unchanged, non-ECR/digest/untagged passthrough with zero ECR calls) and `TestSociImageManifestDigest`. All pass; `go vet` clean; full module builds; `terraform fmt` clean.

## Verify after deploy

1. Deploy (incl. the IAM change).
2. Call `/applications/store/registry` (or launch a notebook on a version with a `-soci` index) and confirm `imageUrl` returns `…@sha256:<soci-manifest>` rather than the `:<tag>`.
3. Launch the notebook → task def references that digest → measure `pullStartedAt→pullStoppedAt` vs the ~11.4s baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)